### PR TITLE
Proof of concept for generic validator using name as an example

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -45,7 +45,8 @@ export const archiveForm = (payload: TIndexPayload): TArchiveAction => ({
   payload
 });
 
-export const removeArchivedForm = (payload: TIndexPayload): TRemoveArchivedAction => ({
+export const removeArchivedForm =
+(payload: TIndexPayload): TRemoveArchivedAction => ({
   type: 'REMOVE_ARCHIVED_FORM',
   payload
 });

--- a/src/selectors/character.ts
+++ b/src/selectors/character.ts
@@ -1,5 +1,6 @@
 import {createSelector} from 'reselect';
-import {formStateSelector} from './form';
+import {formStateSelector, createFormFieldSelector} from './form';
+import {rulesSelector} from './rules';
 import {
   IForm,
   ICharacter,
@@ -13,18 +14,20 @@ import {
   lte,
   pipe,
   filter,
-  isNil
+  isNil,
+  path
 } from 'ramda';
+import {
+  isValid,
+  maxStringLengthValidation,
+  minStringLengthValidation,
+  maxNumberValidation,
+} from '../utils/validation';
 
 export const characterFormSelector = createSelector(
   formStateSelector,
   (form: IForm) => form.character
 );
-
-// TODO: Move this to its own file
-const rulesSelector = (state: IAppState) => {
-  return state.rules;
-};
 
 const raceAlignmentSelector = createSelector(
   rulesSelector,
@@ -68,10 +71,13 @@ export const isAgeValidSelector = createSelector(
   }
 );
 
+// Let's do an abstracted example and a non abstracted example
 export const isNameValidSelector = createSelector(
-  characterFormSelector,
-  (character: ICharacter)  => character.name &&
-  gte(character.name.length, 3) && lte(character.name.length, 50)
+  createFormFieldSelector(['character','name']),
+  isValid(
+    maxStringLengthValidation(50),
+    minStringLengthValidation(3),
+  ),
 );
 
 export const isSkillsValidSelector = createSelector(

--- a/src/selectors/character.ts
+++ b/src/selectors/character.ts
@@ -9,12 +9,8 @@ import {
   IAppState
 } from '../store/types';
 import {
-  isEmpty,
   gte,
   lte,
-  pipe,
-  filter,
-  isNil,
   path
 } from 'ramda';
 import {
@@ -22,6 +18,7 @@ import {
   maxStringLengthValidation,
   minStringLengthValidation,
   maxNumberValidation,
+  arrayNotEmptyValidation
 } from '../utils/validation';
 
 export const characterFormSelector = createSelector(
@@ -37,6 +34,19 @@ const raceAlignmentSelector = createSelector(
 export const bioSummarySelector = createSelector(
   characterFormSelector,
   (character: ICharacter) => character.bioSummary
+);
+
+export const isNameValidSelector = createSelector(
+  createFormFieldSelector(['character', 'name']),
+  isValid(
+    maxStringLengthValidation(50),
+    minStringLengthValidation(3),
+  ),
+);
+
+export const isSkillsValidSelector = createSelector(
+  createFormFieldSelector(['character', 'skills']),
+  isValid(arrayNotEmptyValidation()),
 );
 
 export const isRaceAlignmentValidSelector = createSelector(
@@ -68,29 +78,6 @@ export const isAgeValidSelector = createSelector(
     case 'Tiefling':
       return gte(bioSummary.age, 35) && lte(bioSummary.age, 53);
     }
-  }
-);
-
-// Let's do an abstracted example and a non abstracted example
-export const isNameValidSelector = createSelector(
-  createFormFieldSelector(['character','name']),
-  isValid(
-    maxStringLengthValidation(50),
-    minStringLengthValidation(3),
-  ),
-);
-
-export const isSkillsValidSelector = createSelector(
-  characterFormSelector,
-  (character: ICharacter)  => {
-    if (isEmpty(character.skills)) {
-      return false;
-    }
-    const hasValue = pipe(
-      filter(isNil),
-      isEmpty
-    );
-    return hasValue(character.skills);
   }
 );
 

--- a/src/selectors/form.ts
+++ b/src/selectors/form.ts
@@ -4,7 +4,7 @@ import { path } from 'ramda';
 
 export const formStateSelector = (state: IAppState) => state.form;
 
-export const createFormFieldSelector = (fieldPath) => createSelector(
+export const createFormFieldSelector = (fieldPath: string[]) => createSelector(
   formStateSelector,
   (form: IForm) => path(fieldPath, form)
 );

--- a/src/selectors/form.ts
+++ b/src/selectors/form.ts
@@ -1,8 +1,13 @@
-import {IAppState} from '../store/types';
+import {IAppState, IForm} from '../store/types';
 import {createSelector} from 'reselect';
-import {IForm} from '../store/types/form';
+import { path } from 'ramda';
 
 export const formStateSelector = (state: IAppState) => state.form;
+
+export const createFormFieldSelector = (fieldPath) => createSelector(
+  formStateSelector,
+  (form: IForm) => path(fieldPath, form)
+);
 
 export const archivedCharactersSelector = createSelector(
   formStateSelector,

--- a/src/selectors/rules.ts
+++ b/src/selectors/rules.ts
@@ -1,6 +1,5 @@
 import { IAppState } from '../store/types';
 
-// TODO: Move this to its own file
 export const rulesSelector = (state: IAppState) => {
   return state.rules;
 };

--- a/src/selectors/rules.ts
+++ b/src/selectors/rules.ts
@@ -1,0 +1,6 @@
+import { IAppState } from '../store/types';
+
+// TODO: Move this to its own file
+export const rulesSelector = (state: IAppState) => {
+  return state.rules;
+};

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,18 @@
+// import { forEach } from 'ramda';
+// return forEach((val) => !val(arg) ? false : true, validators);
+
+export const isValid = (...validators): any => {
+  return (arg: any) => {
+    // TODO: Find appropriate function for this...
+    for (const val of validators) {
+      if (!val(arg)) {
+        return false;
+      }
+    }
+    return true;
+  };
+}
+// Validator functions
+export const maxNumberValidation = (max: number) => (value: number) => value < max;
+export const maxStringLengthValidation = (max: number) => (value: string) => value.length < max;
+export const minStringLengthValidation = (min: number) => (value: string) => value.length > min;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,5 +1,4 @@
-// import { forEach } from 'ramda';
-// return forEach((val) => !val(arg) ? false : true, validators);
+import { isEmpty, pipe, filter, isNil } from 'ramda';
 
 export const isValid = (...validators): any => {
   return (arg: any) => {
@@ -11,8 +10,20 @@ export const isValid = (...validators): any => {
     }
     return true;
   };
-}
+};
+
 // Validator functions
-export const maxNumberValidation = (max: number) => (value: number) => value < max;
-export const maxStringLengthValidation = (max: number) => (value: string) => value.length < max;
-export const minStringLengthValidation = (min: number) => (value: string) => value.length > min;
+export const maxNumberValidation = (max: number) =>
+  (value: number) => value < max;
+export const maxStringLengthValidation = (max: number) =>
+  (value: string) => value.length < max;
+export const minStringLengthValidation = (min: number) =>
+  (value: string) => value.length > min;
+export const arrayNotEmptyValidation = () =>
+  (value: string[]) => {
+    const hasValue = pipe(
+      filter(isNil),
+      isEmpty
+    );
+    return isEmpty(value) ? false : hasValue(value);
+  };


### PR DESCRIPTION
Makes validation more modular/composable/generic.

### So Far
- Proof of concept with name validator
- Adds selector that grabs any given field when provided a path
- Adds a couple generic validation functions + `isValid` pipe function
- Moves rules to a rules selector

### TODO
- Make `isValid` a bit more elegant
- Update tests, probably
- Add types that don't suck, probably